### PR TITLE
To support ToastLength option in ShowMessage method. 

### DIFF
--- a/Toast.Plugin.Abstractions/IToastPopUp.cs
+++ b/Toast.Plugin.Abstractions/IToastPopUp.cs
@@ -4,36 +4,40 @@ namespace Plugin.Toast.Abstractions
 {
     public interface IToastPopUp
     {
-
         /// <summary>
         /// Show Custom Toast
         /// </summary>
         /// <param name="message"></param>
-        void ShowCustomToast(string message, string bgColor, string txtColor);
+        /// <param name="toastLength">Toast length: short = 2 seconds OR long = 3.5 seconds. Optional, defaults to short.</param>
+        void ShowCustomToast(string message, string bgColor, string txtColor, ToastLength toastLength = ToastLength.SHORT);
 
 
         /// <summary>
         /// ShowToastMessage display a Toast MESSAGE
         /// </summary>
         /// <param name="message">Message to display</param>
-        void ShowToastMessage(string message);
+        /// <param name="toastLength">Toast length: short = 2 seconds OR long = 3.5 seconds. Optional, defaults to short.</param>
+        void ShowToastMessage(string message, ToastLength toastLength = ToastLength.SHORT);
 
         /// <summary>
         /// ShowToastError display a Toast ERROR
         /// </summary>
         /// <param name="message">Message to display</param>
-        void ShowToastError(string message);
+        /// <param name="toastLength">Toast length: short = 2 seconds OR long = 3.5 seconds. Optional, defaults to short.</param>
+        void ShowToastError(string message, ToastLength toastLength = ToastLength.SHORT);
 
         /// <summary>
         /// ShowToastWarning display a Toast Warning
         /// </summary>
         /// <param name="message">Message to display</param>
-        void ShowToastWarning(string message);
+        /// <param name="toastLength">Toast length: short = 2 seconds OR long = 3.5 seconds. Optional, defaults to short.</param>
+        void ShowToastWarning(string message, ToastLength toastLength = ToastLength.SHORT);
 
         /// <summary>
         /// ShowToastSuccess display a Toast Success
         /// </summary>
         /// <param name="message">Message to display</param>
-        void ShowToastSuccess(string message);
+        /// <param name="toastLength">Toast length: short = 2 seconds OR long = 3.5 seconds. Optional, defaults to short.</param>
+        void ShowToastSuccess(string message, ToastLength toastLength = ToastLength.SHORT);
     }
 }

--- a/Toast.Plugin.Abstractions/ToastLength.cs
+++ b/Toast.Plugin.Abstractions/ToastLength.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Plugin.Toast.Abstractions
+{
+    public enum ToastLength
+    {
+        SHORT = 0,
+        LONG = 1
+    }
+}

--- a/Toast.Plugin.Android/ShowToastPopUp.cs
+++ b/Toast.Plugin.Android/ShowToastPopUp.cs
@@ -19,46 +19,59 @@ namespace Plugin.Toast
         /// <param name="message"></param>
         /// <param name="bgColor"></param>
         /// <param name="txtColor"></param>
-        public void ShowCustomToast(string message, string bgColor, string txtColor)
+        public void ShowCustomToast(string message, string bgColor, string txtColor, Abstractions.ToastLength toastLength = Abstractions.ToastLength.SHORT)
         {
-            ShowMessage(message, bgColor, txtColor);
+            ShowMessage(message, bgColor, txtColor, toastLength);
         }
 
         /// <summary>
         /// Show a Toast Error
         /// </summary>
         /// <param name="message"></param>
-        public void ShowToastError(string message)
+        public void ShowToastError(string message, Abstractions.ToastLength toastLength = Abstractions.ToastLength.SHORT)
         {
-            ShowMessage(message, "#9f333c", "#ffffff");
+            ShowMessage(message, "#9f333c", "#ffffff", toastLength);
         }
 
         /// <summary>
         /// ShowToastMessage
         /// </summary>
         /// <param name="message"></param>
-        public void ShowToastMessage(string message)
+        public void ShowToastMessage(string message, Abstractions.ToastLength toastLength = Abstractions.ToastLength.SHORT)
         {
             // To dismiss existing toast, otherwise, the screen will be populated with it if the user do so
-            ShowMessage(message, "#000000", "#ffffff");
+            ShowMessage(message, "#000000", "#ffffff", toastLength);
         }
       
         /// <summary>
         /// 
         /// </summary>
         /// <param name="message"></param>
-        public void ShowToastSuccess(string message)
+        public void ShowToastSuccess(string message, Abstractions.ToastLength toastLength = Abstractions.ToastLength.SHORT)
         {
-            ShowMessage(message, "#70B771", "#ffffff");
+            ShowMessage(message, "#70B771", "#ffffff", toastLength);
         }
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="message"></param>
-        public void ShowToastWarning(string message)
+        public void ShowToastWarning(string message, Abstractions.ToastLength toastLength = Abstractions.ToastLength.SHORT)
         {
-            ShowMessage(message, "#faaa1d", "#ffffff");         
+            ShowMessage(message, "#faaa1d", "#ffffff", toastLength);         
+        }
+
+
+        /// <summary>
+        /// Converts common ToastLength type to Android one
+        /// </summary>
+        /// <param name="length">Toast length</param>
+        /// <returns>Android toast length</returns>
+        private Android.Widget.ToastLength CommonToastLengthToPlatformSpecific(Abstractions.ToastLength length)
+        {
+            if (length == Abstractions.ToastLength.LONG)
+                return Android.Widget.ToastLength.Long;
+            return Android.Widget.ToastLength.Short;
         }
 
         /// <summary>
@@ -66,11 +79,11 @@ namespace Plugin.Toast
         /// </summary>
         /// <param name="message"></param>
         /// <param name="backgroundHexColor"></param>
-        private void ShowMessage(string message, string backgroundHexColor = null, string textHexColor = null)
+        private void ShowMessage(string message, string backgroundHexColor = null, string textHexColor = null, Abstractions.ToastLength toastLength = Abstractions.ToastLength.SHORT)
         {
             // To dismiss existing toast, otherwise, the screen will be populated with it if the user do so
-            _instance?.Cancel();
-            _instance = Android.Widget.Toast.MakeText(Android.App.Application.Context, message, ToastLength.Short);
+            _instance?.Cancel();            
+            _instance = Android.Widget.Toast.MakeText(Android.App.Application.Context, message, CommonToastLengthToPlatformSpecific(toastLength));
             View tView = _instance.View;
             if (!string.IsNullOrEmpty(backgroundHexColor))
                 tView.Background.SetColorFilter(Color.ParseColor(backgroundHexColor), PorterDuff.Mode.SrcIn);//Gets the actual oval background of the Toast then sets the color filter

--- a/Toast.Plugin.UWP/ShowToastPopUp.cs
+++ b/Toast.Plugin.UWP/ShowToastPopUp.cs
@@ -1,4 +1,5 @@
 ﻿using Plugin.Toast.Abstractions;
+using System;
 using Windows.Data.Xml.Dom;
 using Windows.UI.Notifications;
 
@@ -6,7 +7,14 @@ namespace Plugin.Toast
 {
     public class ShowToastPopUp : IToastPopUp
     {
-        public void ShowToastError(string message)
+        private System.DateTimeOffset ConvertCommonToastLengthToPlatformSpecific(ToastLength toastLength)
+        {
+            if (toastLength == ToastLength.LONG)
+                return new System.DateTimeOffset(DateTime.Now, TimeSpan.FromSeconds(3.5));
+            return new System.DateTimeOffset(DateTime.Now, TimeSpan.FromSeconds(2));
+        }
+
+        public void ShowToastError(string message, ToastLength toastLength = ToastLength.SHORT)
         {
             ToastTemplateType toastTemplate = ToastTemplateType.ToastImageAndText01;
             XmlDocument toastXml = ToastNotificationManager.GetTemplateContent(toastTemplate);
@@ -19,12 +27,13 @@ namespace Plugin.Toast
 
             // Create the toast notification based on the XML content you've specified.
             ToastNotification toast = new ToastNotification(toastXml);
+            toast.ExpirationTime = ConvertCommonToastLengthToPlatformSpecific(toastLength);
 
             // Send your toast notification.
             ToastNotificationManager.CreateToastNotifier().Show(toast);
         }
 
-        public void ShowToastMessage(string message)
+        public void ShowToastMessage(string message, ToastLength toastLength = ToastLength.SHORT)
         {
             ToastTemplateType toastTemplate = ToastTemplateType.ToastImageAndText01;
             XmlDocument toastXml = ToastNotificationManager.GetTemplateContent(toastTemplate);
@@ -37,12 +46,13 @@ namespace Plugin.Toast
 
             // Create the toast notification based on the XML content you've specified.
             ToastNotification toast = new ToastNotification(toastXml);
+            toast.ExpirationTime = ConvertCommonToastLengthToPlatformSpecific(toastLength);
 
             // Send your toast notification.
             ToastNotificationManager.CreateToastNotifier().Show(toast);
         }
 
-        public void ShowToastSuccess(string message)
+        public void ShowToastSuccess(string message, ToastLength toastLength = ToastLength.SHORT)
         {
             ToastTemplateType toastTemplate = ToastTemplateType.ToastImageAndText01;
             XmlDocument toastXml = ToastNotificationManager.GetTemplateContent(toastTemplate);
@@ -55,12 +65,13 @@ namespace Plugin.Toast
 
             // Create the toast notification based on the XML content you've specified.
             ToastNotification toast = new ToastNotification(toastXml);
+            toast.ExpirationTime = ConvertCommonToastLengthToPlatformSpecific(toastLength);
 
             // Send your toast notification.
             ToastNotificationManager.CreateToastNotifier().Show(toast);
         }
 
-        public void ShowToastWarning(string message)
+        public void ShowToastWarning(string message, ToastLength toastLength = ToastLength.SHORT)
         {
             ToastTemplateType toastTemplate = ToastTemplateType.ToastImageAndText01;
             XmlDocument toastXml = ToastNotificationManager.GetTemplateContent(toastTemplate);
@@ -73,12 +84,13 @@ namespace Plugin.Toast
 
             // Create the toast notification based on the XML content you've specified.
             ToastNotification toast = new ToastNotification(toastXml);
+            toast.ExpirationTime = ConvertCommonToastLengthToPlatformSpecific(toastLength);
 
             // Send your toast notification.
             ToastNotificationManager.CreateToastNotifier().Show(toast);
         }
 
-        public void ShowToastMessage(string message, string backgroundHexColor = null, string textHexColor = null)
+        public void ShowToastMessage(string message, string backgroundHexColor = null, string textHexColor = null, ToastLength toastLength = ToastLength.SHORT)
         {
             ToastTemplateType toastTemplate = ToastTemplateType.ToastImageAndText01;
             XmlDocument toastXml = ToastNotificationManager.GetTemplateContent(toastTemplate);
@@ -91,12 +103,13 @@ namespace Plugin.Toast
 
             // Create the toast notification based on the XML content you've specified.
             ToastNotification toast = new ToastNotification(toastXml);
+            toast.ExpirationTime = ConvertCommonToastLengthToPlatformSpecific(toastLength);
 
             // Send your toast notification.
             ToastNotificationManager.CreateToastNotifier().Show(toast);
         }
 
-        public void ShowCustomToast(string message, string bgColor, string txtColor)
+        public void ShowCustomToast(string message, string bgColor, string txtColor, ToastLength toastLength = ToastLength.SHORT)
         {
             ToastTemplateType toastTemplate = ToastTemplateType.ToastImageAndText01;
             XmlDocument toastXml = ToastNotificationManager.GetTemplateContent(toastTemplate);
@@ -109,6 +122,7 @@ namespace Plugin.Toast
 
             // Create the toast notification based on the XML content you've specified.
             ToastNotification toast = new ToastNotification(toastXml);
+            toast.ExpirationTime = ConvertCommonToastLengthToPlatformSpecific(toastLength);
 
             // Send your toast notification.
             ToastNotificationManager.CreateToastNotifier().Show(toast);

--- a/Toast.Plugin.iOS/ShowToastPopUp.cs
+++ b/Toast.Plugin.iOS/ShowToastPopUp.cs
@@ -23,9 +23,19 @@ namespace Plugin.Toast
             _alertDelay?.Dispose();
         }
 
-        private void ShowToast(string message, string backgroundHexColor = null, string textHexColor = null)
+        private double ConvertCommonToastLengthToPlatformSpecific(ToastLength toastLength)
         {
-            _alertDelay = NSTimer.CreateScheduledTimer(ShortDelay, (obj) =>
+            if (toastLength == ToastLength.LONG)
+                return LongDelay;
+            return ShortDelay;
+        }
+
+
+        private void ShowToast(string message, string backgroundHexColor = null, string textHexColor = null, ToastLength toastLength = ToastLength.SHORT)
+        {
+            double delay = ConvertCommonToastLengthToPlatformSpecific(toastLength);
+
+            _alertDelay = NSTimer.CreateScheduledTimer(delay, (obj) =>
             {
                 DismissMessage();
             });
@@ -52,36 +62,36 @@ namespace Plugin.Toast
         /// in a Toast
         /// </summary>
         /// <param name="message"></param>
-        public void ShowToastMessage(string message)
+        public void ShowToastMessage(string message, ToastLength toastLength = ToastLength.SHORT)
         {
-            ShowToast(message, "#000000" , "#ffffff");
+            ShowToast(message, "#000000" , "#ffffff", toastLength);
         }
 
         /// <summary>
         /// ShowToastError
         /// </summary>
         /// <param name="message"></param>
-        public void ShowToastError(string message)
+        public void ShowToastError(string message, ToastLength toastLength = ToastLength.SHORT)
         {
-            ShowToast(message, "#9f333c", "#ffffff");
+            ShowToast(message, "#9f333c", "#ffffff", toastLength);
         }
 
         /// <summary>
         /// ShowToastWarning
         /// </summary>
         /// <param name="message"></param>
-        public void ShowToastWarning(string message)
+        public void ShowToastWarning(string message, ToastLength toastLength = ToastLength.SHORT)
         {
-            ShowToast(message, "#faaa1d", "#ffffff");
+            ShowToast(message, "#faaa1d", "#ffffff", toastLength);
         }
 
         /// <summary>
         /// ShowToastSuccess
         /// </summary>
         /// <param name="message"></param>
-        public void ShowToastSuccess(string message)
+        public void ShowToastSuccess(string message, ToastLength toastLength = ToastLength.SHORT)
         {
-            ShowToast(message, "#70B771", "#ffffff");
+            ShowToast(message, "#70B771", "#ffffff", toastLength);
         }
 
         /// <summary>
@@ -90,9 +100,9 @@ namespace Plugin.Toast
         /// <param name="message"></param>
         /// <param name="bgColor"></param>
         /// <param name="txtColor"></param>
-        public void ShowCustomToast(string message, string bgColor, string txtColor)
+        public void ShowCustomToast(string message, string bgColor, string txtColor, ToastLength toastLength = ToastLength.SHORT)
         {
-            ShowToast(message, bgColor, txtColor);
+            ShowToast(message, bgColor, txtColor, toastLength);
         }
     }
 }

--- a/Toast.Plugin.iOS/Toast.Plugin.iOS.csproj
+++ b/Toast.Plugin.iOS/Toast.Plugin.iOS.csproj
@@ -65,5 +65,8 @@
       <Name>Toast.Plugin.Abstractions</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/Toast.Plugin.iOS/packages.config
+++ b/Toast.Plugin.iOS/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Runtime" version="4.3.1" targetFramework="xamarinios10" />
+</packages>


### PR DESCRIPTION
I added toast length parameter to all ShowMessage overloads. SHORT and LONG options are now supported and can be passed when calling ShowMessage methods from .NET Standard library. 

