### PR TITLE
To resolve crash on Android 11

### DIFF
--- a/Toast.Plugin.Android/ShowToastPopUp.cs
+++ b/Toast.Plugin.Android/ShowToastPopUp.cs
@@ -1,4 +1,5 @@
 ﻿using Android.Graphics;
+using Android.OS;
 using Android.Views;
 using Android.Widget;
 using Plugin.Toast.Abstractions;
@@ -74,13 +75,19 @@ namespace Plugin.Toast
             // To dismiss existing toast, otherwise, the screen will be populated with it if the user do so
             _instance?.Cancel();
             _instance = Android.Widget.Toast.MakeText(Android.App.Application.Context, message, length);
-            View tView = _instance.View;
-            if (!string.IsNullOrEmpty(backgroundHexColor))
-                tView.Background.SetColorFilter(Color.ParseColor(backgroundHexColor), PorterDuff.Mode.SrcIn);//Gets the actual oval background of the Toast then sets the color filter
 
-            TextView text = (TextView)tView.FindViewById(Android.Resource.Id.Message);
-            if (!string.IsNullOrEmpty(textHexColor))
-                text.SetTextColor(Color.ParseColor(textHexColor));
+            if (Android.OS.Build.VERSION.SdkInt < BuildVersionCodes.R)
+            {
+                View tView = _instance.View;
+                if (!string.IsNullOrEmpty(backgroundHexColor))
+                    tView.Background.SetColorFilter(Color.ParseColor(backgroundHexColor),
+                        PorterDuff.Mode
+                            .SrcIn); //Gets the actual oval background of the Toast then sets the color filter
+
+                TextView text = (TextView) tView.FindViewById(Android.Resource.Id.Message);
+                if (!string.IsNullOrEmpty(textHexColor))
+                    text.SetTextColor(Color.ParseColor(textHexColor));
+            }
             _instance.Show();
         }
 

--- a/Toast.Plugin.Android/Toast.Plugin.Android.csproj
+++ b/Toast.Plugin.Android/Toast.Plugin.Android.csproj
@@ -14,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v11.0.99</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
This fix resolves crash on Android 11 that occurs any time the ShowMessage method is called. It crashes because custom toast notifications are no longer supported on Android 11.